### PR TITLE
allow to skip `plot_show()` to be able to get the current axis

### DIFF
--- a/causalimpact/main.py
+++ b/causalimpact/main.py
@@ -223,7 +223,7 @@ class CausalImpact():
     def plot(
         self,
         panels: List[str] = ['original', 'pointwise', 'cumulative'],
-        figsize: Tuple[int] = (10, 7)
+        figsize: Tuple[int] = (10, 7), show: bool = True
     ) -> None:
         """
         Plots the graphic with results associated to Causal Impact.
@@ -238,9 +238,15 @@ class CausalImpact():
               data and its forecasts.
           figsize: Tuple[int]
               Sets the width and height of the figure to plot.
+          show: bool
+            If true, runs plt.show(), i.e., displays the figure.
+            If false, it gives acess to the axis, i.e., the figure can be saved
+            and the style of the plot can be modified by getting the axis with
+            `ax = plt.gca()` or the figure with `fig = plt.gcf()`.
+            Defaults to True.
         """
         plotter.plot(self.inferences, self.pre_data, self.post_data, panels=panels,
-                     figsize=figsize)
+                     figsize=figsize, show=show)
 
     def summary(self, output: str = 'summary', digits: int = 2) -> str:
         """

--- a/causalimpact/main.py
+++ b/causalimpact/main.py
@@ -223,7 +223,8 @@ class CausalImpact():
     def plot(
         self,
         panels: List[str] = ['original', 'pointwise', 'cumulative'],
-        figsize: Tuple[int] = (10, 7), show: bool = True
+        figsize: Tuple[int] = (10, 7),
+        show: bool = True
     ) -> None:
         """
         Plots the graphic with results associated to Causal Impact.
@@ -239,11 +240,12 @@ class CausalImpact():
           figsize: Tuple[int]
               Sets the width and height of the figure to plot.
           show: bool
-            If true, runs plt.show(), i.e., displays the figure.
-            If false, it gives acess to the axis, i.e., the figure can be saved
-            and the style of the plot can be modified by getting the axis with
-            `ax = plt.gca()` or the figure with `fig = plt.gcf()`.
-            Defaults to True.
+            If `True` then plots the figure by running `plt.plot()`.
+            If `False` then nothing will be plotted which allows for accessing and
+            manipulating the figure and axis of the plot, i.e., the figure can be saved
+            and the styling can be modified. To get the axis, just run:
+            `import matplotlib.pyplot as plt; ax = plt.gca()` or the figure:
+            `fig = plt.gcf()`. Defaults to `True`.
         """
         plotter.plot(self.inferences, self.pre_data, self.post_data, panels=panels,
                      figsize=figsize, show=show)

--- a/causalimpact/plot.py
+++ b/causalimpact/plot.py
@@ -26,7 +26,8 @@ def plot(
     pre_data: pd.DataFrame,
     post_data: pd.DataFrame,
     panels=['original', 'pointwise', 'cumulative'],
-    figsize=(10, 7)
+    figsize=(10, 7),
+    show=True
 ) -> None:
     """Plots inferences results related to causal impact analysis.
 
@@ -36,7 +37,8 @@ def plot(
         Indicates which plot should be considered in the graphics.
       figsize: tuple.
         Changes the size of the graphics plotted.
-
+      show: bool. 
+        If true, runs plt.show(), i.e., displays the figure. Defaults to True.
     Raises
     ------
       RuntimeError: if inferences were not computed yet.
@@ -132,7 +134,8 @@ def plot(
         ax.axhline(y=0, color='gray', linestyle='--')
         ax.legend()
         ax.grid(True, color='gainsboro')
-    plt.show()
+    if show:
+        plt.show()
 
 
 def get_plotter():  # pragma: no cover

--- a/causalimpact/plot.py
+++ b/causalimpact/plot.py
@@ -37,7 +37,7 @@ def plot(
         Indicates which plot should be considered in the graphics.
       figsize: tuple.
         Changes the size of the graphics plotted.
-      show: bool. 
+      show: bool.
         If true, runs plt.show(), i.e., displays the figure. Defaults to True.
     Raises
     ------

--- a/causalimpact/plot.py
+++ b/causalimpact/plot.py
@@ -38,7 +38,11 @@ def plot(
       figsize: tuple.
         Changes the size of the graphics plotted.
       show: bool.
-        If true, runs plt.show(), i.e., displays the figure. Defaults to True.
+        If true, runs plt.show(), i.e., displays the figure.
+        If false, it gives acess to the axis, i.e., the figure can be saved
+        and the style of the plot can be modified by getting the axis with
+        `ax = plt.gca()` or the figure with `fig = plt.gcf()`.
+        Defaults to True.
     Raises
     ------
       RuntimeError: if inferences were not computed yet.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -199,7 +199,7 @@ def test_plotter(monkeypatch, rand_data, pre_int_period, post_int_period):
     ci.plot()
     plotter_mock.plot.assert_called_with('inferences', 'pre_data', 'post_data',
                                          panels=['original', 'pointwise', 'cumulative'],
-                                         figsize=(10, 7))
+                                         figsize=(10, 7), show=True)
 
 
 def test_summarizer(monkeypatch, rand_data, pre_int_period, post_int_period):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -683,7 +683,7 @@ def test_plot_raises_wrong_input_panel(rand_data, pre_int_period, post_int_perio
     )
 
 
-def test_plot_original_panel_gap_data_show(
+def test_plot_original_panel_gap_data_show_is_false(
     rand_data, pre_int_gap_period, post_int_gap_period, inferences, monkeypatch
 ):
     plot_mock = mock.Mock()
@@ -719,5 +719,5 @@ def test_plot_original_panel_gap_data_show(
 
     ax_mock.grid.assert_called_with(True, color="gainsboro")
     ax_mock.legend.assert_called()
-    # if show == False, then plt.show() should not have been called
+    # If `show == False` then `plt.show()` should not have been called
     plot_mock.return_value.show.assert_not_called()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -682,12 +682,13 @@ def test_plot_raises_wrong_input_panel(rand_data, pre_int_period, post_int_perio
         '"original", "pointwise", "cumulative".'
     )
 
+
 def test_plot_original_panel_gap_data_show(
     rand_data, pre_int_gap_period, post_int_gap_period, inferences, monkeypatch
 ):
     plot_mock = mock.Mock()
-    pre_data = rand_data.loc[pre_int_gap_period[0] : pre_int_gap_period[1]]
-    post_data = rand_data.loc[post_int_gap_period[0] : post_int_gap_period[1]]
+    pre_data = rand_data.loc[pre_int_gap_period[0]: pre_int_gap_period[1]]
+    post_data = rand_data.loc[post_int_gap_period[0]: post_int_gap_period[1]]
     pre_post_index = pre_data.index.union(post_data.index)
     monkeypatch.setattr("causalimpact.plot.get_plotter", plot_mock)
     plotter.plot(inferences, pre_data, post_data, panels=["original"], show=False)


### PR DESCRIPTION
Hi, thanks for this great library!

This PR does not do much, it only allows that users can get the current matplotlib axis to change the style of the plot or to save the figure. That is, it should also address dafiti/causalimpact#72.

Using the show argument is similar to what, for example, SHAP does https://github.com/slundberg/shap/blob/3711be957461c3747d4f788e8604c5568ffb2d90/shap/plots/_violin.py#L19-L27