### PR TITLE
Fix python version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,6 @@ setup(
     project_urls={
         'Source': 'https://github.com/WillianFuks/tfcausalimpact'
     },
-    python_requires='>=3, <3.10.*',
+    python_requires='>=3, <3.10',
     test_suite='tests'
 )


### PR DESCRIPTION
<3.10.* is not a valid PEP440 version specifier

This version constraint breaks installation via poetry and other package management tools