### PR TITLE
Read summary templates via context manager to avoid unclosed files

### DIFF
--- a/causalimpact/summary.py
+++ b/causalimpact/summary.py
@@ -29,8 +29,10 @@ _here = os.path.dirname(os.path.abspath(__file__))
 summary_tmpl_path = os.path.join(_here, 'summary', 'templates', 'summary')
 report_tmpl_path = os.path.join(_here, 'summary', 'templates', 'report')
 
-SUMMARY_TMPL = Template(open(summary_tmpl_path).read())
-REPORT_TMPL = Template(open(report_tmpl_path).read())
+with open(summary_tmpl_path) as f:
+    SUMMARY_TMPL = Template(f.read())
+with open(report_tmpl_path) as f:
+    REPORT_TMPL = Template(f.read())
 
 
 def summary(


### PR DESCRIPTION
Missing explicit `close` call on template files sometimes leads to the file descriptors left unclosed. In some cases, this can manifest itself in tests if warnings are treated as errors. Using context managers fixes the issue