### PR TITLE
Update tensorflow-probability version range

### DIFF
--- a/.github/workflows/run-CI.yml
+++ b/.github/workflows/run-CI.yml
@@ -6,24 +6,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
           - os: macos-latest
-            python: 3.7
+            python: '3.8'
           - os: macos-latest
-            python: 3.8
-          - os: macos-latest
-            python: 3.9
+            python: '3.9'
           - os: macos-latest
             python: '3.10'
           - os: macos-latest
             python: '3.11'
           - os: windows-latest
-            python: 3.7
+            python: '3.8'
           - os: windows-latest
-            python: 3.8
-          - os: windows-latest
-            python: 3.9
+            python: '3.9'
           - os: windows-latest
             python: '3.10'
           - os: windows-latest

--- a/causalimpact/__version__.py
+++ b/causalimpact/__version__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = '0.0.17'
+__version__ = '0.0.18'

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     'jinja2',
     'pandas >= 1.3.5, <= 2.2',
     'tensorflow >= 2.10',
-    'tensorflow-probability[tf] >= 0.18, <= 0.24',
+    'tensorflow-probability[tf] >= 0.18, <= 0.25',
     'matplotlib',
 ]
 


### PR DESCRIPTION
Loosening the requirements allows for the installation of the newer version 0.25 of tensorflow-probability, enabling the installation of tensorflow 2.18 and consequently numpy 2.0.